### PR TITLE
Add `renovate.json.sample` file

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -1,3 +1,6 @@
+[hooks]
+pre = ["pre-script.rhai"]
+
 [placeholders.registry]
 type = "string"
 prompt = "[Github action template] To what registry will this policy be published?"

--- a/pre-script.rhai
+++ b/pre-script.rhai
@@ -1,0 +1,1 @@
+file::rename("renovate.json.sample", "renovate.json");

--- a/renovate.json.sample
+++ b/renovate.json.sample
@@ -1,0 +1,7 @@
+{
+  "extends": [
+    "config:base",
+    "group:allNonMajor",
+    "schedule:earlyMondays"
+  ]
+}


### PR DESCRIPTION
This file will get renamed to `renovate.json` when `cargo-generate`
runs.

This allows us to have this file ignored by `renovate` in the template
repository, but have the expected outcome when running `cargo
generate` on the source repo.