### PR TITLE
Update Cargo dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-k8s-openapi = { version = "0.11.0", features = ["v1_20"] }
-kubewarden-policy-sdk = "0.3.1"
+k8s-openapi = { version = "0.14.0", default_features = false, features = ["v1_23"] }
+kubewarden-policy-sdk = "0.4.1"
 lazy_static = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
* Use latest version of the rust SDK
* Update to a more recent version of k8s-openapi
