### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,9 @@ edition = "2018"
 crate-type = ["cdylib"]
 
 [dependencies]
-k8s-openapi = { version = "0.14.0", default_features = false, features = ["v1_23"] }
-kubewarden-policy-sdk = "0.4.1"
+k8s-openapi = { version = "0.15.0", default_features = false, features = ["v1_24"] }
+kubewarden-policy-sdk = "0.6.0"
 lazy_static = "1.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 slog = "2.7"
-wapc-guest = "0.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use lazy_static::lazy_static;
 
-extern crate wapc_guest as guest;
 use guest::prelude::*;
+use kubewarden_policy_sdk::wapc_guest as guest;
 
 use k8s_openapi::api::core::v1 as apicore;
 
@@ -45,6 +45,8 @@ fn validate(payload: &[u8]) -> CallResult {
                 );
                 kubewarden::reject_request(
                     Some(format!("pod name {} is not accepted", &pod_name)),
+                    None,
+                    None,
                     None,
                 )
             } else {


### PR DESCRIPTION
Update to latest version of kubewarden SDK and k8s-openapi.
Fix all the compilation errors caused by API changes.