### PR TITLE
e2e-tests: allow subsequent invocations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SOURCE_FILES := $(shell test -e src/ && find src -type f)
 
 policy.wasm: $(SOURCE_FILES) Cargo.*
 	cargo build --target=wasm32-unknown-unknown --release
-	mv target/wasm32-unknown-unknown/release/*.wasm policy.wasm
+	cp target/wasm32-unknown-unknown/release/*.wasm policy.wasm
 
 annotated-policy.wasm: policy.wasm metadata.yml
 	kwctl annotate -m metadata.yml -o annotated-policy.wasm policy.wasm


### PR DESCRIPTION
Prior to this commit, subsequent invocations of the `e2e-tests` task would fail when no change was done to the policy.
