### PR TITLE
Change Rust WebAssembly compilation target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 SOURCE_FILES := $(shell test -e src/ && find src -type f)
 
 policy.wasm: $(SOURCE_FILES) Cargo.*
-	cargo build --target=wasm32-unknown-unknown --release
-	cp target/wasm32-unknown-unknown/release/*.wasm policy.wasm
+	cargo build --target=wasm32-wasi --release
+	cp target/wasm32-wasi/release/*.wasm policy.wasm
 
 annotated-policy.wasm: policy.wasm metadata.yml
 	kwctl annotate -m metadata.yml -o annotated-policy.wasm policy.wasm


### PR DESCRIPTION
TL;DR: we changed our compilation target from `wasm32-unknown-unknown` to `wasm32-wasi` to ensure Rust policies do not panic at runtime.

The problem
===========

Rebuilding existing Rust policies using a freshly updated `Cargo.lock` or building a new Rust policy from scratch leads to a WebAssembly module that cannot be loaded neither by Policy Server nor by kwctl.

Loading the policy leads to an immediate panic because the WebAssembly runtime provided by Kubewarden does not provide some functions that are imported by the module.

Background information
======================

Prior to this commit, all our Rust policies were built using the `wasm32-unknown-unknown` target.

The `wasm32-unknown-unknown` target is the only one supported by the `wasm-bindgen` crate (see https://rustwasm.github.io/docs/wasm-bindgen/reference/rust-targets.html).

When being used, the `wasm-bindgen` crate causes the final WebAssembly module to import extra functions at runtime.
These extra functions are provided by the runtime (a web browser) by using some JavaScript code offered by the `wasm-bindgen` developers.

We actually don't need `wasm-bindgen` crate. We chose the `wasm32-unknown-unknown` target because, when `wasm-bindgen` is not required, no function is imported from the runtime. We appreciated this minimal approach, because the WebAssembly modules of our policies depend only on importing the waPC host functions.

The root cause
==============

The majority of our Kubewarden Rust policies depend on the `k8s-openapi` crate, which requires the `chrono` crate.

Starting from the `chrono` 0.4.20 release, the crate is requiring the `wasm-bindgen` crate when the build target is `wasm32-unknown-unknown`.

The change has been introduced with this commit https://github.com/chronotope/chrono/commit/27c05589ac269596fe4b047552bc735ebe9ee44c

We cannot force older versions of `chrono` to be used, because they are affected by security issues that have been fixed with the 0.4.20 release.

Because of this change, rebuilding our policies with a `chrono` release major or equal to 0.4.20, leads to a WebAssembly module that imports the following functions:

- `__wbindgen_placeholder__.__wbindgen_describe`
- `__wbindgen_placeholder__.__wbindgen_throw`
- `__wbindgen_externref_xform__.__wbindgen_externref_table_grow`

Our WebAssembly runtime cannot provide implementations of these functions, hence a Rust panic will happen.

The solution
============

Looking at the `chrono` commit that introduced the change, it's clear that this was a deliberate action done to improve the user experience of the developers using the `wasm32-unknown-unknown` target.

More libraries could be using the same approach, we simply haven't run into that yet.

The easiest solution is to use the `wasm32-wasi` target, which is something closer to what we are doing: running WebAssembly on the server side.

No change is needed to our WebAssembly runtime, since this is already running with the WASI snapshot enabled. As a matter of fact, the WebAssembly modules we are producing with TinyGo, Swift and C# are already targeting the WASI target. It's time for our Rust policies to join their ranks.
