### PR TITLE
fix: allow `make` execution on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SOURCE_FILES := $(shell test -e src/ && find src -type f)
-VERSION := $(shell sed --posix -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)
+VERSION := $(shell sed -n 's,^version = \"\(.*\)\",\1,p' Cargo.toml)
 
 policy.wasm: $(SOURCE_FILES) Cargo.*
 	cargo build --target=wasm32-wasi --release


### PR DESCRIPTION
Fix the `sed` invocation to make it compatible with the version
shipped by macOS.

Fixes https://github.com/kubewarden/rust-policy-template/issues/33

Tested on a macOS machine
