### PR TITLE
build: remove artifacthub-pkg.yml dependency when annotating a policy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ artifacthub-pkg.yml: metadata.yml Cargo.toml
 	kwctl scaffold artifacthub --metadata-path metadata.yml --version $(VERSION) \
 		--questions-path questions-ui.yml --output artifacthub-pkg.yml
 
-annotated-policy.wasm: policy.wasm metadata.yml artifacthub-pkg.yml
+annotated-policy.wasm: policy.wasm metadata.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm
 
 .PHONY: fmt


### PR DESCRIPTION
## Description

Removes artifacthub-pkg.yml dependency from annotated-policy.wasm target
See: https://github.com/kubewarden/go-policy-template/pull/56

The same applies to rust policies, since we are using `check-artifacthub` composable in action in [the rust release policy workflow](https://github.com/kubewarden/github-actions/blob/3803f05360d9a30415a0f3033761218b0d59e2ab/.github/workflows/reusable-release-policy-rust.yml#L37)
