### PR TITLE
enable testing

### DIFF
--- a/.github/workflows/cargo-generate-test.yml
+++ b/.github/workflows/cargo-generate-test.yml
@@ -1,0 +1,28 @@
+name: Try to expand local template using cargo-generate
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Render template and build
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_NAME: demo
+      CARGO_GENERATE_VALUE_REGISTRY: ghcr.io
+      CARGO_GENERATE_VALUE_REGISTRY_MODULE_PATH_PREFIX: "kubewarden/policies"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cargo-generate/cargo-generate-action@latest
+        with:
+          name: ${{ env.PROJECT_NAME }}
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      # we need to move the generated project to a temp folder, away from the template project
+      # otherwise `cargo` runs would fail
+      # see https://github.com/rust-lang/cargo/issues/9922
+      - name: test
+        run: |
+          mv $PROJECT_NAME ${{ runner.temp }}/
+          cd ${{ runner.temp }}/$PROJECT_NAME
+          cargo clippy -- -D warnings
+          cargo test

--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -12,7 +12,7 @@ prompt = "[Github action template] What registry path prefix will this policy ha
 default = "kubewarden/policies"
 
 [template]
-cargo_generate_version = ">=0.12.0"
+cargo_generate_version = ">=0.18.0"
 include = [
   "Cargo.toml",
   "artifacthub-pkg.yml",
@@ -21,3 +21,4 @@ include = [
   "README.md",
   ".github/workflows/release.yml",
 ]
+igore = [".github/workflows/cargo-generate-test.yml"]


### PR DESCRIPTION
Render the template and make sure the demo policy works.

**WARNING:** this PR fails because our template policy currently doesn't compile. I propose to fix the compilation issue with another PR

Some additional notes:

GH actions used to be disabled on this repo because the templating of the files like `Cargo.toml` cause the usual checks to fail.

This PR introduces a new action that takes care of rendering the repository and running some sanity checks against it.
The new GH action is ignored by `cargo-generate`, meaning our downstream users will NOT get it.

In the meantime I've also enabled the GH actions support for this repo (so that the new action could run). I disabled manually the `test` and the `release`.

They have to stay disabled because 
* the test one: it cannot run because of the templating, but this is now covered by the new action the PR introduces
* the release action: we don't want to release this policy at all

I didn't want to rename these actions, because otherwise dependabot would not have updated them.
