### PR TITLE
Fix online tutorial

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,7 @@ mod tests {
             name: String::from("Valid name"),
             fixture_file: String::from(request_file),
             expected_validation_result: true,
-            settings: Settings {},
+            settings: Settings::default(),
         };
 
         let res = tc.eval(validate).unwrap();
@@ -97,7 +97,7 @@ mod tests {
             name: String::from("Bad name"),
             fixture_file: String::from(request_file),
             expected_validation_result: false,
-            settings: Settings {},
+            settings: Settings::default(),
         };
 
         let res = tc.eval(validate).unwrap();
@@ -117,7 +117,7 @@ mod tests {
             name: String::from("Ingress creation"),
             fixture_file: String::from(request_file),
             expected_validation_result: true,
-            settings: Settings {},
+            settings: Settings::default(),
         };
 
         let res = tc.eval(validate).unwrap();


### PR DESCRIPTION
This changes the way the settings class is built inside of the tests.
That's required to ensure the online tutorial works as expected.

The tutorial changes the `Settings` class to have a `HashSet` attribute. This causes the invocations of `let s Settings = Settings {}` to fail because the new attribute is not specified.

Moving to use the `Default::default` contructor fixes everything.

This is required to unblock https://github.com/kubewarden/docs/pull/295
