### PR TITLE
chore: remove actions-rs/toolchain github action.

### DIFF
--- a/.github/workflows/cargo-generate-test.yml
+++ b/.github/workflows/cargo-generate-test.yml
@@ -15,11 +15,8 @@ jobs:
         with:
           name: ${{ env.PROJECT_NAME }}
       - name: Prepare Rust environment
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          target: wasm32-wasip1
+        run: |
+          rustup toolchain install stable --profile minimal --target wasm32-wasip1
       - name: Install kwctl
         uses: kubewarden/github-actions/kwctl-installer@v3.1.11
       - name: Install bats


### PR DESCRIPTION
## Description

Removes the deprecated actions-rs/toolchain Github actions used to setup Rust toolchains. Replacing it by calls to the rustup command directly relying on the binaries installed in the workflow runner.

Related to https://github.com/kubewarden/kubewarden-controller/issues/1093
