### PR TITLE
fix: typo in cargo-generate.toml.

### DIFF
--- a/cargo-generate.toml
+++ b/cargo-generate.toml
@@ -22,4 +22,4 @@ include = [
   "README.md",
   ".github/workflows/release.yml",
 ]
-igore = ["Makefile", ".github/workflows/cargo-generate-test.yml"]
+ignore = ["Makefile", ".github/workflows/cargo-generate-test.yml"]


### PR DESCRIPTION
## Description

Fix a typo in the cargo-generate configuration file in the configuration to list files to be ignored.

