### PR TITLE
Update GitHub Actions to latest reusable workflows

### DIFF
--- a/.github/workflows/cargo-generate-test.yml
+++ b/.github/workflows/cargo-generate-test.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           rustup toolchain install stable --profile minimal --target wasm32-wasip1
       - name: Install kwctl
-        uses: kubewarden/github-actions/kwctl-installer@v3.1.11
+        uses: kubewarden/github-actions/kwctl-installer@v4.5.3
       - name: Install bats
         run: sudo apt install -y bats
       - name: Move rendered template

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
       # Required by cosign keyless signing
       id-token: write
 
-    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@v4.0.0
+    # uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@v4.0.0
+    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@v4.1.0
     with:
       oci-target: {{ registry }}/{{ registry_module_path_prefix }}/{{ project-name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
 
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v4.0.0
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v4.5.3
 
   release:
     needs: test
@@ -24,7 +24,6 @@ jobs:
       # Required by cosign keyless signing
       id-token: write
 
-    # uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@v4.0.0
-    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@v4.1.0
+    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@v4.5.3
     with:
       oci-target: {{ registry }}/{{ registry_module_path_prefix }}/{{ project-name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,5 +3,4 @@ name: Continuous integration
 jobs:
   test:
     name: run tests and linters
-    # uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v4.0.0
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v4.1.0
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v4.5.3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,4 +3,5 @@ name: Continuous integration
 jobs:
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v4.0.0
+    # uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v4.0.0
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v4.1.0


### PR DESCRIPTION
This PR updates the reusable GitHub Actions workflows from v4.0.0 to v4.1.0:
- `reusable-test-policy-rust.yml`
- `reusable-release-policy-rust.yml`

This ensures the latest underlying GitHub Actions like `checkout@v4.2.2` are being used.

Closes #55
